### PR TITLE
docs: fix type confusion for option:prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm i egg-static --save
 
 egg-static support all configurations in [koa-static-cache](https://github.com/koajs/static-cache). and with default configurations below:
 
-- prefix: `/public/`
+- prefix: `'/public/'`
 - dir: `path.join(appInfo.baseDir, 'app/public')`
 - dynamic: `true`
 - preload: `false`


### PR DESCRIPTION
When I tried to config prefix, there was some confusion about what type of `prefix` is. I set prefix to a RegExp `/upload/` but got an error, so I looked up document for ` koa-static-cache` and found out it should be a `String`. So I think it may not be friendly for new users(like me).

![image](https://user-images.githubusercontent.com/559179/33313452-a47887ec-d465-11e7-9440-664de41512db.png)
