### PR TITLE
feat: add switch of range

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ egg-static support all configurations in [koa-static-cache](https://github.com/k
 
 `egg-static` provides one more option:
 
+- range: (bool) - range request implementation for egg-static or not, default is `true`.
+
 - maxFiles: the maximum value of cache items, only effective when dynamic is true, default is `1000`.
 
 **All static files in `$baseDir/app/public` can be visited with prefix `/public`, and all the files are lazy loaded.**

--- a/app/middleware/static.js
+++ b/app/middleware/static.js
@@ -9,6 +9,12 @@ const LRU = require('ylru');
 
 module.exports = (options, app) => {
   const dirs = options.dir;
+  const middlewares = [];
+
+  if (!options.disableRange) {
+    middlewares.push(range);
+  }
+
   if (options.dynamic && !options.files) {
     options.files = new LRU(options.maxFiles);
   }
@@ -20,10 +26,11 @@ module.exports = (options, app) => {
 
     app.loggers.coreLogger.info('[egg-static] starting static serve %s -> %s', options.prefix, options.dir);
 
-    return compose([ range, staticCache(options) ]);
+    middlewares.push(staticCache(options));
+
+    return compose(middlewares);
   }
 
-  const middlewares = [ range ];
 
   for (const [ idx, dir ] of dirs.entries()) {
     // copy origin options to new options

--- a/app/middleware/static.js
+++ b/app/middleware/static.js
@@ -11,7 +11,7 @@ module.exports = (options, app) => {
   const dirs = options.dir;
   const middlewares = [];
 
-  if (!options.disableRange) {
+  if (options.range !== false) {
     middlewares.push(range);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
none

##### Description of change
<!-- Provide a description of the change below this comment. -->

增加断点下载功能的配置开关，因为我在业务中会遇到这样的场景，比如：
前端提供的下载地址是 http://www.t.com/1
原来的逻辑是到了egg层会返回302跳转到 http://www.bbb.com/2

但如果加了range断点续传中间件，用户在请求
``` bash
curl -r 10-20 http://www.t.com/1
``` 
会返回302响应体中的10-20的内容，而不是302状态码直接跳转了。

可能会问，为什么用户不是请求302跳转后的地址，再用断点续传range？
这个问题我暂时也搞不懂，但业务情况中印度用户确确实实会在原来地址请求上加上range请求头。