### PR TITLE
fix: 修复 dirs 选项

### DIFF
--- a/app/middleware/static.js
+++ b/app/middleware/static.js
@@ -9,8 +9,7 @@ const LRU = require('ylru');
 const is = require('is-type-of');
 
 module.exports = (options, app) => {
-  let dirs = options.dir;
-  if (!is.array(dirs)) dirs = [ dirs ];
+  const dirs = (options.dirs || []).concat(options.dir);
 
   const prefixs = [];
 

--- a/test/fixtures/static-server-with-dirs/config/config.default.js
+++ b/test/fixtures/static-server-with-dirs/config/config.default.js
@@ -5,7 +5,7 @@ module.exports = appInfo => {
     keys: 'aaa',
     static: {
       prefix: '/public',
-      dir: [
+      dirs: [
         path.join(appInfo.baseDir, '/app/public'),
         {
           prefix: '/static',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
egg-static

##### Description of change
<!-- Provide a description of the change below this comment. -->
这里有两个修复方案：
- 第一个是修改文档
  - 把 `app.config.static.dirs` 去掉，改成 `app.config.static.dir`
  - 涉及 `config/config.default.js` 和 `README.md` 修改
- 第二是使用此 PR 的方案
  -  启用 `dirs` 选项

为了不受歧义的影响，建议还是开启使用 `dirs` 选项来区分